### PR TITLE
Fix entryOptions side effects

### DIFF
--- a/tests/entry-options.test.ts
+++ b/tests/entry-options.test.ts
@@ -157,4 +157,22 @@ describe('Workflow with entryOptions', () => {
     // Non-entry step should keep original options
     expect(mockAction2).toHaveBeenCalledWith({ param: 'value2' });
   });
+
+  it('should not mutate step options after run', async () => {
+    const step = {
+      id: 'entryStep',
+      action: 'test',
+      options: { foo: 'bar' }
+    };
+    const mockAction = jest.fn((opts: any) => opts);
+    const workflow = new Workflow({ steps: [step] });
+    await workflow.run({
+      actions: { test: mockAction },
+      entry: 'entryStep',
+      entryOptions: { foo: 'baz' }
+    });
+
+    // Original options should remain unchanged
+    expect(step.options).toEqual({ foo: 'bar' });
+  });
 });


### PR DESCRIPTION
## Summary
- avoid mutating step options when applying `entryOptions`
- adjust option preparation functions
- add regression test verifying step option immutability

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_683fba1cd14c832f87697ae21155db13